### PR TITLE
Replace support button by search song on youtube

### DIFF
--- a/logic/presence.js
+++ b/logic/presence.js
@@ -54,7 +54,7 @@ functions.updatePresence = function (songInfo, botInfo) {
                 small_text: `Made by ${developer}`,
             },
             buttons: [{ label: `Invite`, url: inviteUrl },
-            { label: `Support`, url: supportUrl }],
+            { label: 'Song on Youtube', url: 'https://www.youtube.com/results?search_query=' + (encodeURIComponent(songName ? songName : '')) }],
         },
     }).catch(console.error);
 };


### PR DESCRIPTION
Replaces the 'support' button in the rpc to 'song on youtube' that opens youtube with the current song title as search query.

Possibly add a different fallback if song title is not present?